### PR TITLE
Enable RealSense color stream with Unity

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Upon launching the RealSense Tool Tracker, the application will attempt to load 
 
 ### Additional Resources
 A sample Python and a C# Unity scripts is provided for receiving and processing the tracking data via UDP.
+The Unity script can also display JPEG encoded color frames when the **Send Color** option is enabled in the tracker.
 
 ## Contributing
 Contributions are welcome! When submitting a pull request, please include a description of your improvements and reference any relevant issue numbers.

--- a/Unity/UDPToolTrackingReceiver.cs
+++ b/Unity/UDPToolTrackingReceiver.cs
@@ -18,12 +18,17 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 #endif
+using UnityEngine.UI;
 public class UDPToolTrackingReceiver : MonoBehaviour
 {
 
     public int port = 12345; // The port number should match the one you are sending on.
     public int toolID = 1; // The tool ID should match the one you are sending on.
     private Queue<ToolTrackingData> receivedUDPPacketQueue = new Queue<ToolTrackingData>();
+    private Queue<byte[]> receivedImageQueue = new Queue<byte[]>();
+
+    public RawImage colorImage;
+    private Texture2D colorTexture;
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
     public struct ToolTrackingData
@@ -88,14 +93,19 @@ public class UDPToolTrackingReceiver : MonoBehaviour
             {
                 byte[] receivedBytes = new byte[reader.UnconsumedBufferLength];
                 reader.ReadBytes(receivedBytes);
-
-                // Convert the bytes received into the structure we're expecting
-                ToolTrackingData trackingData = ByteArrayToStructure<ToolTrackingData>(receivedBytes);
-                // Debug.Log($"Received: Timestamp - {trackingData.timestamp}, Position - ({trackingData.posX}, {trackingData.posY}, {trackingData.posZ}), Rotation - ({trackingData.rotX}, {trackingData.rotY}, {trackingData.rotZ}, {trackingData.rotW}), Tool ID - {trackingData.toolId}");
-                // Filter by toolID if necessary
-                if (trackingData.toolId == toolID)
+                if (receivedBytes.Length == Marshal.SizeOf(typeof(ToolTrackingData)))
                 {
-                    receivedUDPPacketQueue.Enqueue(trackingData);
+                    ToolTrackingData trackingData = ByteArrayToStructure<ToolTrackingData>(receivedBytes);
+                    if (trackingData.toolId == toolID)
+                    {
+                        receivedUDPPacketQueue.Enqueue(trackingData);
+                    }
+                }
+                else if (receivedBytes.Length > 4 && receivedBytes[0] == (byte)'I' && receivedBytes[1] == (byte)'M' && receivedBytes[2] == (byte)'G')
+                {
+                    byte[] img = new byte[receivedBytes.Length - 4];
+                    Array.Copy(receivedBytes, 4, img, 0, img.Length);
+                    receivedImageQueue.Enqueue(img);
                 }
             }
         }
@@ -137,11 +147,19 @@ public class UDPToolTrackingReceiver : MonoBehaviour
             try
             {
                 byte[] data = client.Receive(ref anyIP);
-                ToolTrackingData trackingData = ByteArrayToStructure<ToolTrackingData>(data);
-                // Debug.Log($"Received: Timestamp - {trackingData.timestamp}, Position - ({trackingData.posX}, {trackingData.posY}, {trackingData.posZ}), Rotation - ({trackingData.rotX}, {trackingData.rotY}, {trackingData.rotZ}, {trackingData.rotW}), Tool ID - {trackingData.toolId}");
-                if (trackingData.toolId == toolID)
+                if (data.Length == Marshal.SizeOf(typeof(ToolTrackingData)))
                 {
-                    receivedUDPPacketQueue.Enqueue(trackingData);
+                    ToolTrackingData trackingData = ByteArrayToStructure<ToolTrackingData>(data);
+                    if (trackingData.toolId == toolID)
+                    {
+                        receivedUDPPacketQueue.Enqueue(trackingData);
+                    }
+                }
+                else if (data.Length > 4 && data[0] == (byte)'I' && data[1] == (byte)'M' && data[2] == (byte)'G')
+                {
+                    byte[] img = new byte[data.Length - 4];
+                    Buffer.BlockCopy(data, 4, img, 0, img.Length);
+                    receivedImageQueue.Enqueue(img);
                 }
             }
             catch (ObjectDisposedException)
@@ -181,6 +199,18 @@ public class UDPToolTrackingReceiver : MonoBehaviour
             // Right-handed to left-handed coordinate system conversion
             transform.position = new Vector3(trackingData.posX, trackingData.posZ, trackingData.posY);
             transform.rotation = new Quaternion(trackingData.rotX, trackingData.rotZ, trackingData.rotY, - trackingData.rotW);
+        }
+
+        if (receivedImageQueue.Count > 0)
+        {
+            byte[] img = receivedImageQueue.Dequeue();
+            if (colorTexture == null)
+                colorTexture = new Texture2D(2, 2);
+            colorTexture.LoadImage(img);
+            if (colorImage != null)
+            {
+                colorImage.texture = colorTexture;
+            }
         }
     }
 

--- a/include/IRToolTracking.h
+++ b/include/IRToolTracking.h
@@ -113,7 +113,12 @@ public:
     cv::Mat getNextIRFrame() {
         std::lock_guard<std::mutex> lock(mtx_frames);
         return trackingFrame;
-    }   
+    }
+
+    cv::Mat getNextColorFrame() {
+        std::lock_guard<std::mutex> lock(mtx_frames);
+        return colorFrame;
+    }
 
 private:
 
@@ -126,6 +131,7 @@ private:
     std::mutex mtx_frames;
     cv::Mat trackingFrame;
     cv::Mat depthFrame;
+    cv::Mat colorFrame;
 
     std::atomic<bool> Terminated = ATOMIC_VAR_INIT(false);
     std::shared_ptr<std::thread> Thread;

--- a/include/ViewerWindow.h
+++ b/include/ViewerWindow.h
@@ -53,6 +53,7 @@ private:
 
     std::shared_ptr<std::thread> udpThread;
     bool udpEnabled = false;
+    bool sendColor = false;
 
     std::shared_ptr<std::thread> udpReceiveThread;
     bool multiEnabled = false;
@@ -63,7 +64,7 @@ private:
     std::map<long long, Eigen::Matrix4f> extrinsics;
 
     GLFWwindow* window = nullptr;
-    GLuint texture = 0, dtexture = 0;
+    GLuint texture = 0, dtexture = 0, ctexture = 0;
     std::vector<Tool> tools;
     std::map<int, Eigen::Matrix4f> toolTransforms;
     std::mutex secondaryDataMutex;

--- a/src/IRToolTracking.cpp
+++ b/src/IRToolTracking.cpp
@@ -35,6 +35,7 @@ void IRToolTracking::initializeFromFile(const std::string& file) {
 
     // Load the configuration from file
     config.enable_device_from_file(file);
+    config.enable_stream(RS2_STREAM_COLOR);
     intrinsics_found = false;
     Terminated = false;
     playFromFile = true;
@@ -73,6 +74,7 @@ void IRToolTracking::initialize(int index, int width, int height) {
 
     config.enable_stream(RS2_STREAM_INFRARED, 1, frame_width, frame_height, RS2_FORMAT_Y8, 90);
     config.enable_stream(RS2_STREAM_DEPTH, frame_width, frame_height, RS2_FORMAT_Z16, 90);
+    config.enable_stream(RS2_STREAM_COLOR, frame_width, frame_height, RS2_FORMAT_BGR8, 30);
 
     Terminated = false;
 }
@@ -166,6 +168,7 @@ void IRToolTracking::processStreams() {
 
         rs2::frame ir_frame_left = frames.get_infrared_frame(1);
         rs2::frame depth_frame = frames.get_depth_frame();
+        rs2::frame color_frame = frames.get_color_frame();
 
         depth_frame = spat_filter.process(depth_frame); // Apply Spatial Filter
         depth_frame = temp_filter.process(depth_frame); // Apply Temporal Filter
@@ -176,6 +179,11 @@ void IRToolTracking::processStreams() {
             std::lock_guard<std::mutex> lock(mtx_frames);
             depthFrame = cv::Mat(cv::Size(frame_width, frame_height), CV_8UC3,
                 (void*)colorized_depth.get_data(), cv::Mat::AUTO_STEP).clone();
+            if (color_frame)
+            {
+                colorFrame = cv::Mat(cv::Size(frame_width, frame_height), CV_8UC3,
+                    (void*)color_frame.get_data(), cv::Mat::AUTO_STEP).clone();
+            }
         }
 
         // Get intrinsic parameters of the depth sensor if not already retrieved

--- a/src/ViewerWindow.cpp
+++ b/src/ViewerWindow.cpp
@@ -383,6 +383,25 @@ void ViewerWindow::UdpThreadFunction()
                     }
                 }
             }
+
+            if (sendColor && m_connected)
+            {
+                cv::Mat cframe = tracker.getNextColorFrame();
+                if (!cframe.empty())
+                {
+                    cv::Mat resized;
+                    cv::resize(cframe, resized, cv::Size(cframe.cols/2, cframe.rows/2));
+                    std::vector<uchar> enc;
+                    cv::imencode(".jpg", resized, enc, {cv::IMWRITE_JPEG_QUALITY, 50});
+                    if (enc.size() + 4 < 65000)
+                    {
+                        std::vector<uint8_t> buf(enc.size() + 4);
+                        buf[0] = 'I'; buf[1] = 'M'; buf[2] = 'G'; buf[3] = '0';
+                        std::copy(enc.begin(), enc.end(), buf.begin() + 4);
+                        nanosockets_send(socket, &sendAddress, buf.data(), buf.size());
+                    }
+                }
+            }
         }
 
         int sleepDurationMs = 1000 / frequency; // Convert frequency to sleep duration in milliseconds
@@ -487,6 +506,7 @@ void ViewerWindow::Render() {
     // Generate textures
     glGenTextures(1, &texture);
     glGenTextures(1, &dtexture);
+    glGenTextures(1, &ctexture);
 
     ImGuiWindowFlags overlayFlags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar |
                                     ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize |
@@ -746,6 +766,8 @@ void ViewerWindow::Render() {
         ImGui::SetNextItemWidth(110);
         ImGui::InputInt("Frequency", &frequency);
         ImGui::SameLine();
+        ImGui::Checkbox("Send Color", &sendColor);
+        ImGui::SameLine();
         if (ImGui::Checkbox("UDP", &udpEnabled))
         {
             if (udpEnabled)
@@ -825,6 +847,7 @@ void ViewerWindow::Render() {
 
         cv::Mat frame = tracker.getNextIRFrame();
         cv::Mat depth = tracker.getNextDepthFrame();
+        cv::Mat color = tracker.getNextColorFrame();
 
         if (!depth.empty() && (tracker.IsTrackingTools() || calibrationInitiated))
         {
@@ -850,6 +873,19 @@ void ViewerWindow::Render() {
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, depth.cols, depth.rows, 0, GL_RGB, GL_UNSIGNED_BYTE, depth.data);
             ImGui::Image(reinterpret_cast<void *>(static_cast<intptr_t>(dtexture)), ImVec2(424, 240));
             ImGui::End();
+
+            if (!color.empty())
+            {
+                ImGui::SetNextWindowPos(ImVec2(20, windowHeight - 560));
+                ImGui::Begin("Color Monitor", nullptr, overlayFlags);
+                glBindTexture(GL_TEXTURE_2D, ctexture);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+                glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, color.cols, color.rows, 0, GL_BGR, GL_UNSIGNED_BYTE, color.data);
+                ImGui::Image(reinterpret_cast<void *>(static_cast<intptr_t>(ctexture)), ImVec2(424, 240));
+                ImGui::End();
+            }
         }
 
         if (tracker.IsTrackingTools())
@@ -922,6 +958,7 @@ void ViewerWindow::Render() {
 void ViewerWindow::StopRender() {
     glDeleteTextures(1, &texture);
     glDeleteTextures(1, &dtexture);
+    glDeleteTextures(1, &ctexture);
     ImGui_ImplGlfw_Shutdown();
     ImGui_ImplOpenGL3_Shutdown();
     ImGui::DestroyContext();


### PR DESCRIPTION
## Summary
- capture and expose the camera color stream
- add option to send JPEG frames over UDP
- extend the Unity receiver to display incoming images
- update viewer and docs

## Testing
- `cmake ..` *(fails: Xinerama, Xcursor, XInput, and RealSense SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_688349e73c648331997749aba2e9b5dd